### PR TITLE
LoroWebsocketClient race condition fix in react strict mode

### DIFF
--- a/packages/loro-websocket/src/client/index.ts
+++ b/packages/loro-websocket/src/client/index.ts
@@ -1544,6 +1544,7 @@ export class LoroWebsocketClient {
 
   private sendJoinPayload(payload: Uint8Array) {
     if (this.safeSend(this.ws, payload, "join")) return;
+    if (!this.shouldReconnect) return;
     this.enqueueJoin(payload);
     void this.connect();
   }

--- a/packages/loro-websocket/tests/e2e.test.ts
+++ b/packages/loro-websocket/tests/e2e.test.ts
@@ -1087,7 +1087,7 @@ describe("React strict-mode: join + immediate close", () => {
   }, 15000);
 
   it("close() before auth microtask settles does not resurrect the client", async () => {
-    const statuses: ClientStatus[] = [];
+    const statuses: string[] = [];
     const client = new LoroWebsocketClient({
       url: `ws://localhost:${port}`,
     });

--- a/packages/loro-websocket/tests/e2e.test.ts
+++ b/packages/loro-websocket/tests/e2e.test.ts
@@ -1072,6 +1072,47 @@ describe("E2E: RoomError rejoin policy", () => {
   }, 8000);
 });
 
+describe("React strict-mode: join + immediate close", () => {
+  let server: SimpleServer;
+  let port: number;
+
+  beforeAll(async () => {
+    port = await getPort();
+    server = new SimpleServer({ port });
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  }, 15000);
+
+  it("close() before auth microtask settles does not resurrect the client", async () => {
+    const statuses: ClientStatus[] = [];
+    const client = new LoroWebsocketClient({
+      url: `ws://localhost:${port}`,
+    });
+    await client.waitConnected();
+
+    client.onStatusChange(s => statuses.push(s));
+
+    // Simulate React strict-mode: effect fires join(), cleanup fires close()
+    const adaptor = new LoroAdaptor();
+    client.join({ roomId: "strict-mode-zombie", crdtAdaptor: adaptor });
+    client.close(); // shouldReconnect = false
+
+    // Let the resolveAuth().then(sendJoinPayload) microtask fire
+    await new Promise(r => setTimeout(r, 500));
+
+    // The client must stay dead — no Connecting/Connected after Disconnected
+    expect(client.getStatus()).toBe(ClientStatus.Disconnected);
+    expect(
+      statuses.filter(s => s === ClientStatus.Connecting)
+    ).toHaveLength(0);
+
+    client.destroy();
+  }, 5000);
+});
+
 function installMockWindow(initialOnline = true) {
   const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
     globalThis,


### PR DESCRIPTION
* Reproduce race condition error with `LoroWebsocketClient` when mounting in effect in react strict mode via unit test
* Fix the race condition

## Explanation

In development, react has a thing called "strict mode" which mounts, then unmounts, then re-mounts all components.

`sendJoinPayload` calls `void this.connect()` as a fallback retry. `connect()` unconditionally sets `shouldReconnect = true`, which resurrects a client that was intentionally closed via `close()`. This manifests in React strict mode where `useEffect` creates a client + joins a room, and the cleanup function calls `close()` but a deferred microtask from `resolveAuth().then(sendJoinPayload)` fires after `close()`, calling `connect()` and creating a zombie WebSocket connection.

A piece of sample code that would cause this fire is:

```ts
useEffect(() => {
    const client = new LoroWebsocketClient({ url: "ws://localhost:3000" });
    void client.connect();
    client.join({ roomId: "my-room", crdtAdaptor: new LoroAdaptor() });

    return () => {
      client.close();
    };
  }, []);
```