### PR TITLE
fix(loro-websocket): settle reconnect-adopter promises on destroy to avoid unhandled rejections

### DIFF
--- a/packages/loro-websocket/src/client/index.test.ts
+++ b/packages/loro-websocket/src/client/index.test.ts
@@ -6,7 +6,7 @@ import {
   type JoinError,
 } from "loro-protocol";
 import * as protocol from "loro-protocol";
-import { LoroWebsocketClient } from "./index";
+import { LoroWebsocketClient, ClientStatus } from "./index";
 
 class FakeWebSocket {
   static CONNECTING = 0;
@@ -138,5 +138,60 @@ describe("LoroWebsocketClient", () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
 
+  });
+
+  it("does not leave unhandled promise rejections when destroy() is called during an in-flight reconnect attempt", async () => {
+    // Reproduces the reconnect-adopter leak: scheduleReconnect()'s retry timer
+    // calls `void this.connect()` as a bare, unreferenced call. `connect()` is
+    // async and (on its normal path) just returns the shared
+    // `connectedPromise`, so each such call creates its own "adopter" promise
+    // chained to that shared promise. The shared promise itself is protected
+    // by a `.catch(() => {})` in `ensureConnectedPromise()`, but that does not
+    // protect these separate adopter promises. If `destroy()` rejects the
+    // shared promise while a reconnect attempt is still in flight, every
+    // accumulated adopter promise rejects too, with no handler anywhere.
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const client = new LoroWebsocketClient({
+        url: "ws://test",
+        disablePing: true,
+        reconnect: { enabled: true, initialDelayMs: 5, maxDelayMs: 5, jitter: 0 },
+      });
+
+      // Bring the initial socket to Connected.
+      const firstWs = (client as any).ws as FakeWebSocket;
+      firstWs.readyState = FakeWebSocket.OPEN;
+      firstWs.dispatch("open", {});
+      expect(client.getStatus()).toBe(ClientStatus.Connected);
+
+      // Simulate an unexpected close, which schedules a reconnect attempt.
+      firstWs.readyState = FakeWebSocket.CLOSED;
+      firstWs.dispatch("close", { code: 1006, reason: "" });
+
+      // Wait for the reconnect timer to fire. This creates a new socket via
+      // scheduleReconnect()'s bare `void this.connect()` call - the adopter
+      // promise from the bug report.
+      await new Promise(resolve => setTimeout(resolve, 30));
+
+      // A second (never-opened) socket is now the active reconnect attempt.
+      expect((client as any).ws).not.toBe(firstWs);
+
+      // Destroying mid-reconnect rejects the shared connectedPromise. Without
+      // the fix, the adopter promise created above has no catch handler.
+      client.destroy();
+
+      // Give Node's event queue a chance to report any unhandled rejection
+      // before we assert.
+      await new Promise(resolve => setTimeout(resolve, 30));
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+
+    expect(unhandled).toHaveLength(0);
   });
 });

--- a/packages/loro-websocket/src/client/index.ts
+++ b/packages/loro-websocket/src/client/index.ts
@@ -208,7 +208,10 @@ export class LoroWebsocketClient {
 
     // Start initial connection
     this.ensureConnectedPromise();
-    void this.connect();
+    // Same bare-call adopter-promise hazard as scheduleReconnect() (see the
+    // comment there): swallow so a destroy() before this resolves can't
+    // surface as an unhandled rejection.
+    this.connect().catch(() => { });
   }
 
   private async resolveAuth(auth?: AuthOption): Promise<Uint8Array> {
@@ -557,7 +560,14 @@ export class LoroWebsocketClient {
     const delay = immediate ? 0 : this.computeBackoffDelay(attempt);
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
-      void this.connect();
+      // `connect()` is async and, on its normal path, just returns the
+      // shared `connectedPromise` - so this call creates its own "adopter"
+      // promise chained to that shared promise. `ensureConnectedPromise()`
+      // only protects the shared promise itself; if it's later rejected
+      // (e.g. `destroy()` mid-reconnect) while this adopter promise has no
+      // handler, it surfaces as an unhandled rejection. Swallow it here;
+      // callers observe failures via `waitConnected()`/`onStatusChange`.
+      this.connect().catch(() => { });
     }, delay);
   }
 
@@ -1551,7 +1561,9 @@ export class LoroWebsocketClient {
   private sendJoinPayload(payload: Uint8Array) {
     if (this.safeSend(this.ws, payload, "join")) return;
     this.enqueueJoin(payload);
-    void this.connect();
+    // Same bare-call adopter-promise hazard as scheduleReconnect() (see the
+    // comment there).
+    this.connect().catch(() => { });
   }
 
   private flushQueuedJoins() {


### PR DESCRIPTION

## Problem

`LoroWebsocketClient` can produce unhandled promise rejections when
`destroy()` is called while a reconnect attempt (or the initial connect, or
a deferred join-triggered connect) is still in flight. In a long-running
Node process or test suite that exercises real disconnects, this can
surface as process-level "Unhandled Rejection" warnings/failures even
though every public API call the caller made behaved correctly.

## Root cause

`connect()` is `async`; on its normal path it just returns the shared
`connectedPromise` (`return this.connectedPromise;`). Because `connect()`
is itself async, its *own* returned promise is a separate object that
adopts/chains to `connectedPromise` — it is not the same promise instance
that `ensureConnectedPromise()` protects with
`this.connectedPromise.catch(() => {})`.

Three call sites invoke `connect()` as a bare, unreferenced statement
(`void this.connect();`):
- `scheduleReconnect()`'s retry timer — the main source, since every
  automatic reconnect attempt during a disconnect episode creates its own
  adopter promise this way.
- The constructor's initial connect.
- `sendJoinPayload()`'s fallback connect.

When `destroy()` later rejects the shared `connectedPromise`
(`this.rejectConnected?.(new Error("Destroyed"))`), every accumulated
adopter promise from those bare calls rejects too, with no handler
anywhere.

Verified this is still present in released 0.6.2 and at current HEAD: 0.6.2
added a redundant `.catch()` on the *shared* promise at `close()`/`destroy()`,
which does not protect the separate adopter promises.

## Fix

Attach a no-op `.catch(() => {})` at each of the three bare `connect()`
call sites instead of discarding the promise with `void`. This does not
change observable behavior for callers — connection failures are already
surfaced through `waitConnected()` (which awaits the shared promise) and
through `onError`/`emitError` in `connect()`'s own error path. It only
ensures the adopter promise created at each call site settles cleanly
instead of becoming an independent unhandled-rejection source.

## Test

Added a regression test in `src/client/index.test.ts` that brings a client
to `Connected`, forces an unexpected close (triggering
`scheduleReconnect()`), waits for the reconnect timer to create a new,
never-opened socket (an in-flight reconnect attempt), then calls
`destroy()` while that attempt is still unresolved. The test registers a
`process.on("unhandledRejection", ...)` listener and asserts nothing was
reported. Confirmed the test fails with `Error: Destroyed` (the exact
`destroy()` rejection reason) before the fix, and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
