### PR TITLE
feat(loro-websocket): surface JoinError code and appCode on the join rejection

### DIFF
--- a/packages/loro-websocket/src/client/index.test.ts
+++ b/packages/loro-websocket/src/client/index.test.ts
@@ -6,7 +6,7 @@ import {
   type JoinError,
 } from "loro-protocol";
 import * as protocol from "loro-protocol";
-import { LoroWebsocketClient } from "./index";
+import { JoinFailedError, LoroWebsocketClient } from "./index";
 
 class FakeWebSocket {
   static CONNECTING = 0;
@@ -138,5 +138,54 @@ describe("LoroWebsocketClient", () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
 
+  });
+
+  it("rejects a join with a typed error carrying the code and appCode", async () => {
+    const client = new LoroWebsocketClient({
+      url: "ws://test",
+      disablePing: true,
+      reconnect: { enabled: false },
+    });
+
+    (client as any).connectedPromise?.catch(() => { });
+
+    const adaptor = {
+      crdtType: CrdtType.Loro,
+      setCtx: () => { },
+      getVersion: () => new Uint8Array([0]),
+      handleJoinOk: async () => { },
+      waitForReachingServerVersion: async () => { },
+      destroy: () => { },
+    } satisfies any;
+
+    const joinError: JoinError = {
+      type: MessageType.JoinError,
+      code: JoinErrorCode.AppError,
+      message: "room was purged",
+      appCode: "room_purged",
+      crdt: adaptor.crdtType,
+      roomId: "room",
+    };
+
+    let rejected: unknown;
+    const pending = {
+      room: Promise.resolve({} as any),
+      resolve: () => { },
+      reject: (e: Error) => {
+        rejected = e;
+      },
+      adaptor,
+      roomId: "room",
+    } satisfies any;
+
+    await (client as any).handleJoinError(joinError, pending, adaptor.crdtType + "room");
+
+    expect(rejected).toBeInstanceOf(JoinFailedError);
+    expect(rejected).toMatchObject({
+      code: JoinErrorCode.AppError,
+      appCode: "room_purged",
+      roomId: "room",
+      crdt: CrdtType.Loro,
+    });
   });
 });

--- a/packages/loro-websocket/src/client/index.ts
+++ b/packages/loro-websocket/src/client/index.ts
@@ -24,6 +24,28 @@ import type { CrdtDocAdaptor } from "loro-adaptors";
 
 export * from "loro-adaptors";
 
+/**
+ * Rejection reason for a failed `join`. Carries the wire fields of the
+ * `JoinError` that caused it so callers can branch on `code` — and, for
+ * `app_error`, on the application-defined `appCode` — instead of parsing
+ * `message`. The message text is unchanged from earlier releases.
+ */
+export class JoinFailedError extends Error {
+  readonly crdt: CrdtType;
+  readonly roomId: string;
+  readonly code: JoinErrorCode;
+  readonly appCode?: string;
+
+  constructor(msg: JoinError) {
+    super(`Join failed: ${msg.code} - ${msg.message}`);
+    this.name = "JoinFailedError";
+    this.crdt = msg.crdt;
+    this.roomId = msg.roomId;
+    this.code = msg.code;
+    this.appCode = msg.appCode;
+  }
+}
+
 export type AuthProvider = () => Uint8Array | Promise<Uint8Array>;
 type AuthOption = Uint8Array | AuthProvider;
 
@@ -894,7 +916,7 @@ export class LoroWebsocketClient {
     }
 
     // No retry possible, reject the promise
-    const err = new Error(`Join failed: ${msg.code} - ${msg.message}`);
+    const err = new JoinFailedError(msg);
     this.emitRoomStatus(
       pending.adaptor.crdtType + pending.roomId,
       RoomJoinStatus.Error,


### PR DESCRIPTION
## Motivation

When a join is refused, `LoroWebsocketClient` rejects with a plain `Error` whose only content is the formatted string:

```ts
const err = new Error(`Join failed: ${msg.code} - ${msg.message}`);
```

That leaves an application no way to tell one refusal from another except by parsing that text. The protocol already anticipates this case — `protocol.md` documents `0x7F app_error` as carrying an extra `varString app_code` ("free-form, e.g. `quota_exceeded`"), and `encoding.ts` decodes it faithfully — but the client discards `appCode` (and the numeric `code`) before the value reaches the caller. `protocol.md` also sketches the hook this closes:

> Implementations may expose `onError({ roomId, kind, code, message, app_code? })` for `join` or `room` messages …

Our own use case: our server permanently destroys a room when the underlying record is purged, and refuses any later join for it. Clients must treat that refusal as terminal — evict the local document, stop the reconnect loop — while every other refusal stays retryable. Today we express that by sending `app_error` with a sentinel *message* string and substring-matching it on the client, with a comment next to the matcher saying "switch to `err.code` when the library exposes it". With this change we can send it as an `app_code` and branch on a typed field instead.

## Scope

One narrow change, in `packages/loro-websocket`:

- Add an exported `JoinFailedError extends Error` carrying `code`, `appCode`, `roomId` and `crdt`.
- Reject from `handleJoinError` with it instead of a bare `Error`.

Notes:

- **No wire change.** No new enum member, no renumbering, no encoder/decoder edit — `appCode` was already on the wire and already decoded. Nothing in `rust/` needs a counterpart.
- **Backwards compatible.** `err.message` is byte-identical to before (`Join failed: <code> - <message>`), so consumers still matching on the string are unaffected; `JoinFailedError` is an `Error`, so `instanceof Error` and existing `catch` blocks behave the same.
- The `VersionUnknown` retry path is untouched.

I deliberately left the `onRoomStatusChange` listener signature alone — it already forwards the numeric `code` as `messageCode`, and widening it to carry `appCode` felt like a separate call. Happy to add it here if you'd prefer the two paths to match.

## Tests

`pnpm -r test` — one test added in `packages/loro-websocket/src/client/index.test.ts` asserting an `app_error` join refusal rejects with a `JoinFailedError` exposing `code` and `appCode`. Full suite green (104 passing).

`pnpm lint` is clean (3 pre-existing warnings, 0 errors) and `packages/loro-websocket` typechecks. Two notes on pre-existing state, unrelated to this branch: `pnpm typecheck` fails in `loro-adaptors` (`src/elo-adaptor.ts`, duplicate `CryptoKey` types), and `pnpm format:check` is red for 34 files on `main` — including both files this PR touches — so I matched the surrounding style rather than reformatting them.

Thanks for the protocol and for the work on this repo — happy to adjust the shape of this however you'd like.
